### PR TITLE
BLE Simple Beacon: Update KEIL project and the readme

### DIFF
--- a/connectivity/simple_beacon/Readme.md
+++ b/connectivity/simple_beacon/Readme.md
@@ -79,7 +79,8 @@ Jumpers are placed in default configurations. Refer to the getting started guide
 
 ### Software configuration
 
-  - SDK6.0.12 or later
+
+  - [SDK6.0.14](https://www.dialog-semiconductor.com/da14531_sdk_latest) or later
 
   - ***SEGGER’s J-Link*** tools should be downloaded and installed.
 

--- a/connectivity/simple_beacon/project_environment/simple_beacon.uvoptx
+++ b/connectivity/simple_beacon/project_environment/simple_beacon.uvoptx
@@ -10,7 +10,7 @@
     <aExt>*.s*; *.src; *.a*</aExt>
     <oExt>*.obj; *.o</oExt>
     <lExt>*.lib</lExt>
-    <tExt>*.txt; *.h; *.inc</tExt>
+    <tExt>*.txt; *.h; *.inc; *.md</tExt>
     <pExt>*.plm</pExt>
     <CppX>*.cpp</CppX>
     <nMigrate>0</nMigrate>
@@ -113,7 +113,7 @@
         <tDllPa></tDllPa>
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
-        <tIfile>.\..\..\..\..\..\sdk\common_project_files\misc\sysram_case23.ini</tIfile>
+        <tIfile>C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\sysram_case23.ini</tIfile>
         <pMon>Segger\JL2CM3.dll</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
@@ -147,146 +147,18 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>267</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971322</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\267</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>232</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971234</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\232</Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>208</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971192</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\208</Expression>
-        </Bp>
-        <Bp>
-          <Number>3</Number>
-          <Type>0</Type>
-          <LineNumber>198</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971152</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\198</Expression>
-        </Bp>
-        <Bp>
-          <Number>4</Number>
-          <Type>0</Type>
-          <LineNumber>185</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971136</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\185</Expression>
-        </Bp>
-        <Bp>
-          <Number>5</Number>
-          <Type>0</Type>
-          <LineNumber>161</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>133971422</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\empty_peripheral_template_585\../src/user_simple_beacon.c\161</Expression>
-        </Bp>
-        <Bp>
-          <Number>6</Number>
-          <Type>0</Type>
           <LineNumber>210</LineNumber>
           <EnabledFlag>0</EnabledFlag>
-          <Address>0</Address>
+          <Address>133970774</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
+          <BreakIfRCount>1</BreakIfRCount>
           <Filename>..\src\user_simple_beacon.c</Filename>
           <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>7</Number>
-          <Type>0</Type>
-          <LineNumber>212</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>8</Number>
-          <Type>0</Type>
-          <LineNumber>271</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\user_simple_beacon.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
+          <Expression>\\simple_beacon_585\../src/user_simple_beacon.c\210</Expression>
         </Bp>
       </Breakpoint>
       <MemoryWindow1>
@@ -434,7 +306,7 @@
         <tDllPa></tDllPa>
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
-        <tIfile>.\..\..\..\..\..\sdk\common_project_files\misc\sysram_case23.ini</tIfile>
+        <tIfile>C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\sysram_case23.ini</tIfile>
         <pMon>Segger\JL2CM3.dll</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
@@ -939,7 +811,7 @@
         <tDllPa></tDllPa>
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
-        <tIfile>..\..\..\..\..\sdk\common_project_files\misc\jlink_DA14531.ini</tIfile>
+        <tIfile>C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\jlink_DA14531.ini</tIfile>
         <pMon>Segger\JL2CM3.dll</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
@@ -1047,7 +919,7 @@
 
   <Group>
     <GroupName>sdk_boot</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1058,7 +930,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\boot\system_DA14585_586.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14585_586.c</PathWithFileName>
       <FilenameWithoutPath>system_DA14585_586.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1070,7 +942,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</PathWithFileName>
       <FilenameWithoutPath>startup_DA14585_586.s</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1082,7 +954,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\arch\boot\system_DA14531.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14531.c</PathWithFileName>
       <FilenameWithoutPath>system_DA14531.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1094,7 +966,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14531.s</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14531.s</PathWithFileName>
       <FilenameWithoutPath>startup_DA14531.s</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1106,7 +978,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\hardfault_handler.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\hardfault_handler.c</PathWithFileName>
       <FilenameWithoutPath>hardfault_handler.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1118,7 +990,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\nmi_handler.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\nmi_handler.c</PathWithFileName>
       <FilenameWithoutPath>nmi_handler.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1127,7 +999,7 @@
 
   <Group>
     <GroupName>sdk_arch</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1138,7 +1010,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\core_modules\arch_console\arch_console.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\arch_console\arch_console.c</PathWithFileName>
       <FilenameWithoutPath>arch_console.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1150,7 +1022,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\core_modules\nvds\src\nvds.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\nvds\src\nvds.c</PathWithFileName>
       <FilenameWithoutPath>nvds.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1162,7 +1034,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\arch_main.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_main.c</PathWithFileName>
       <FilenameWithoutPath>arch_main.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1174,7 +1046,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\jump_table.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\jump_table.c</PathWithFileName>
       <FilenameWithoutPath>jump_table.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1186,7 +1058,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\arch_sleep.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_sleep.c</PathWithFileName>
       <FilenameWithoutPath>arch_sleep.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1198,7 +1070,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\arch\main\arch_system.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_system.c</PathWithFileName>
       <FilenameWithoutPath>arch_system.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1210,7 +1082,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\arch\main\arch_rom.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_rom.c</PathWithFileName>
       <FilenameWithoutPath>arch_rom.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1222,7 +1094,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\third_party\rand\chacha20.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\third_party\rand\chacha20.c</PathWithFileName>
       <FilenameWithoutPath>chacha20.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1234,7 +1106,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\third_party\hash\hash.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\third_party\hash\hash.c</PathWithFileName>
       <FilenameWithoutPath>hash.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1246,7 +1118,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14585_586.lib</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14585_586.lib</PathWithFileName>
       <FilenameWithoutPath>da14585_586.lib</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1258,7 +1130,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14531.lib</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14531.lib</PathWithFileName>
       <FilenameWithoutPath>da14531.lib</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1270,7 +1142,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\utilities\otp_cs\otp_cs.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_cs\otp_cs.c</PathWithFileName>
       <FilenameWithoutPath>otp_cs.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1282,7 +1154,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\utilities\otp_hdr\otp_hdr.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_hdr\otp_hdr.c</PathWithFileName>
       <FilenameWithoutPath>otp_hdr.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1291,7 +1163,7 @@
 
   <Group>
     <GroupName>sdk_driver</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1302,7 +1174,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\syscntl\syscntl.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\syscntl\syscntl.c</PathWithFileName>
       <FilenameWithoutPath>syscntl.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1314,7 +1186,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\gpio\gpio.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\gpio\gpio.c</PathWithFileName>
       <FilenameWithoutPath>gpio.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1326,7 +1198,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</PathWithFileName>
       <FilenameWithoutPath>wkupct_quadec.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1338,7 +1210,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\battery\battery.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\battery\battery.c</PathWithFileName>
       <FilenameWithoutPath>battery.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1350,7 +1222,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\adc\adc_58x.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_58x.c</PathWithFileName>
       <FilenameWithoutPath>adc_58x.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1362,7 +1234,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\adc\adc_531.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_531.c</PathWithFileName>
       <FilenameWithoutPath>adc_531.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1374,7 +1246,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\trng\trng.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\trng\trng.c</PathWithFileName>
       <FilenameWithoutPath>trng.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1386,7 +1258,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\spi\spi_58x.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_58x.c</PathWithFileName>
       <FilenameWithoutPath>spi_58x.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1398,7 +1270,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\spi\spi_531.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_531.c</PathWithFileName>
       <FilenameWithoutPath>spi_531.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1410,7 +1282,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\spi_flash\spi_flash.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi_flash\spi_flash.c</PathWithFileName>
       <FilenameWithoutPath>spi_flash.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1422,7 +1294,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</PathWithFileName>
       <FilenameWithoutPath>i2c_eeprom.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1434,7 +1306,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\systick\systick.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\systick\systick.c</PathWithFileName>
       <FilenameWithoutPath>systick.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1446,7 +1318,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\driver\uart\uart.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\uart\uart.c</PathWithFileName>
       <FilenameWithoutPath>uart.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1458,7 +1330,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</PathWithFileName>
       <FilenameWithoutPath>hw_otpc_58x.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1470,7 +1342,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_531.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_531.c</PathWithFileName>
       <FilenameWithoutPath>hw_otpc_531.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1482,7 +1354,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\dma\dma.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\dma\dma.c</PathWithFileName>
       <FilenameWithoutPath>dma.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1494,7 +1366,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\driver\i2c\i2c.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c\i2c.c</PathWithFileName>
       <FilenameWithoutPath>i2c.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1503,7 +1375,7 @@
 
   <Group>
     <GroupName>sdk_ble</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1514,7 +1386,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_585.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_585.c</PathWithFileName>
       <FilenameWithoutPath>rf_585.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1526,7 +1398,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\rwble\rwble.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\rwble\rwble.c</PathWithFileName>
       <FilenameWithoutPath>rwble.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1538,7 +1410,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\platform\core_modules\rwip\src\rwip.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rwip\src\rwip.c</PathWithFileName>
       <FilenameWithoutPath>rwip.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1550,7 +1422,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\core_modules\rf\src\ble_arp.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\ble_arp.c</PathWithFileName>
       <FilenameWithoutPath>ble_arp.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1562,7 +1434,7 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_531.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_531.c</PathWithFileName>
       <FilenameWithoutPath>rf_531.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -1571,7 +1443,7 @@
 
   <Group>
     <GroupName>sdk_profiles</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1582,8 +1454,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\host\att\attm\attm_db_128.c</PathWithFileName>
-      <FilenameWithoutPath>attm_db_128.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\prf.c</PathWithFileName>
+      <FilenameWithoutPath>prf.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1594,8 +1466,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc.c</PathWithFileName>
-      <FilenameWithoutPath>basc.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1.c</PathWithFileName>
+      <FilenameWithoutPath>custs1.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1606,8 +1478,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc_task.c</PathWithFileName>
-      <FilenameWithoutPath>basc_task.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</PathWithFileName>
+      <FilenameWithoutPath>custs1_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1618,8 +1490,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass.c</PathWithFileName>
-      <FilenameWithoutPath>bass.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss.c</PathWithFileName>
+      <FilenameWithoutPath>diss.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1630,8 +1502,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass_task.c</PathWithFileName>
-      <FilenameWithoutPath>bass_task.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</PathWithFileName>
+      <FilenameWithoutPath>diss_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1642,8 +1514,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc.c</PathWithFileName>
-      <FilenameWithoutPath>blpc.c</FilenameWithoutPath>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\host\att\attm\attm_db_128.c</PathWithFileName>
+      <FilenameWithoutPath>attm_db_128.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1654,884 +1526,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>blpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>49</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps.c</PathWithFileName>
-      <FilenameWithoutPath>blps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>50</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps_task.c</PathWithFileName>
-      <FilenameWithoutPath>blps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>51</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc.c</PathWithFileName>
-      <FilenameWithoutPath>disc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>52</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc_task.c</PathWithFileName>
-      <FilenameWithoutPath>disc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>53</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss.c</PathWithFileName>
-      <FilenameWithoutPath>diss.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>54</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</PathWithFileName>
-      <FilenameWithoutPath>diss_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>55</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt.c</PathWithFileName>
-      <FilenameWithoutPath>findt.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>56</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt_task.c</PathWithFileName>
-      <FilenameWithoutPath>findt_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>57</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh.c</PathWithFileName>
-      <FilenameWithoutPath>hogpbh.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>58</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh_task.c</PathWithFileName>
-      <FilenameWithoutPath>hogpbh_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>59</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd.c</PathWithFileName>
-      <FilenameWithoutPath>hogpd.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>60</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd_task.c</PathWithFileName>
-      <FilenameWithoutPath>hogpd_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>61</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh.c</PathWithFileName>
-      <FilenameWithoutPath>hogprh.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>62</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh_task.c</PathWithFileName>
-      <FilenameWithoutPath>hogprh_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>63</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc.c</PathWithFileName>
-      <FilenameWithoutPath>hrpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>64</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>hrpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>65</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps.c</PathWithFileName>
-      <FilenameWithoutPath>hrps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>66</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps_task.c</PathWithFileName>
-      <FilenameWithoutPath>hrps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>67</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc.c</PathWithFileName>
-      <FilenameWithoutPath>htpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>68</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>htpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>69</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt.c</PathWithFileName>
-      <FilenameWithoutPath>htpt.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>70</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt_task.c</PathWithFileName>
-      <FilenameWithoutPath>htpt_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>71</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm.c</PathWithFileName>
-      <FilenameWithoutPath>proxm.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>72</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm_task.c</PathWithFileName>
-      <FilenameWithoutPath>proxm_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>73</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr.c</PathWithFileName>
-      <FilenameWithoutPath>proxr.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>74</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr_task.c</PathWithFileName>
-      <FilenameWithoutPath>proxr_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>75</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc.c</PathWithFileName>
-      <FilenameWithoutPath>scppc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>76</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc_task.c</PathWithFileName>
-      <FilenameWithoutPath>scppc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>77</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps.c</PathWithFileName>
-      <FilenameWithoutPath>scpps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>78</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps_task.c</PathWithFileName>
-      <FilenameWithoutPath>scpps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>79</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc.c</PathWithFileName>
-      <FilenameWithoutPath>anpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>80</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>anpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>81</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps.c</PathWithFileName>
-      <FilenameWithoutPath>anps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>82</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps_task.c</PathWithFileName>
-      <FilenameWithoutPath>anps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>83</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc.c</PathWithFileName>
-      <FilenameWithoutPath>cscpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>84</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>cscpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>85</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps.c</PathWithFileName>
-      <FilenameWithoutPath>cscps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>86</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps_task.c</PathWithFileName>
-      <FilenameWithoutPath>cscps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>87</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc.c</PathWithFileName>
-      <FilenameWithoutPath>glpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>88</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>glpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>89</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps.c</PathWithFileName>
-      <FilenameWithoutPath>glps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>90</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps_task.c</PathWithFileName>
-      <FilenameWithoutPath>glps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>91</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc.c</PathWithFileName>
-      <FilenameWithoutPath>paspc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>92</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc_task.c</PathWithFileName>
-      <FilenameWithoutPath>paspc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>93</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps.c</PathWithFileName>
-      <FilenameWithoutPath>pasps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>94</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps_task.c</PathWithFileName>
-      <FilenameWithoutPath>pasps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>95</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc.c</PathWithFileName>
-      <FilenameWithoutPath>rscpc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>96</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc_task.c</PathWithFileName>
-      <FilenameWithoutPath>rscpc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>97</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps.c</PathWithFileName>
-      <FilenameWithoutPath>rscps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>98</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps_task.c</PathWithFileName>
-      <FilenameWithoutPath>rscps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>99</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc.c</PathWithFileName>
-      <FilenameWithoutPath>tipc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>100</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc_task.c</PathWithFileName>
-      <FilenameWithoutPath>tipc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>101</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips.c</PathWithFileName>
-      <FilenameWithoutPath>tips.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>102</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips_task.c</PathWithFileName>
-      <FilenameWithoutPath>tips_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>103</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl.c</PathWithFileName>
-      <FilenameWithoutPath>findl.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>104</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl_task.c</PathWithFileName>
-      <FilenameWithoutPath>findl_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>105</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc.c</PathWithFileName>
-      <FilenameWithoutPath>cppc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>106</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc_task.c</PathWithFileName>
-      <FilenameWithoutPath>cppc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>107</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps.c</PathWithFileName>
-      <FilenameWithoutPath>cpps.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>108</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps_task.c</PathWithFileName>
-      <FilenameWithoutPath>cpps_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>109</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc.c</PathWithFileName>
-      <FilenameWithoutPath>lanc.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>110</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc_task.c</PathWithFileName>
-      <FilenameWithoutPath>lanc_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>111</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans.c</PathWithFileName>
-      <FilenameWithoutPath>lans.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>112</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans_task.c</PathWithFileName>
-      <FilenameWithoutPath>lans_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>113</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar.c</PathWithFileName>
-      <FilenameWithoutPath>suotar.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>114</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar_task.c</PathWithFileName>
-      <FilenameWithoutPath>suotar_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>115</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custom_common.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custom_common.c</PathWithFileName>
       <FilenameWithoutPath>custom_common.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>116</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1.c</PathWithFileName>
-      <FilenameWithoutPath>custs1.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>117</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</PathWithFileName>
-      <FilenameWithoutPath>custs1_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>118</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2.c</PathWithFileName>
-      <FilenameWithoutPath>custs2.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>119</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2_task.c</PathWithFileName>
-      <FilenameWithoutPath>custs2_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>120</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\ble_stack\profiles\prf.c</PathWithFileName>
-      <FilenameWithoutPath>prf.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>5</GroupNumber>
-      <FileNumber>121</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\ble_stack\profiles\prf_utils.c</PathWithFileName>
-      <FilenameWithoutPath>prf_utils.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -2539,306 +1535,198 @@
 
   <Group>
     <GroupName>sdk_app</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>49</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</PathWithFileName>
       <FilenameWithoutPath>app_default_handlers.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>50</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_common\app.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app.c</PathWithFileName>
       <FilenameWithoutPath>app.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>51</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_task.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_task.c</PathWithFileName>
       <FilenameWithoutPath>app_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>52</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security.c</PathWithFileName>
       <FilenameWithoutPath>app_security.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>53</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security_task.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security_task.c</PathWithFileName>
       <FilenameWithoutPath>app_security_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>54</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass.c</PathWithFileName>
-      <FilenameWithoutPath>app_bass.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>128</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass_task.c</PathWithFileName>
-      <FilenameWithoutPath>app_bass_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>129</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme.c</PathWithFileName>
-      <FilenameWithoutPath>app_findme.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>130</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme_task.c</PathWithFileName>
-      <FilenameWithoutPath>app_findme_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>131</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr.c</PathWithFileName>
-      <FilenameWithoutPath>app_proxr.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>132</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr_task.c</PathWithFileName>
-      <FilenameWithoutPath>app_proxr_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>133</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss.c</PathWithFileName>
       <FilenameWithoutPath>app_diss.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>55</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss_task.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss_task.c</PathWithFileName>
       <FilenameWithoutPath>app_diss_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>56</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar.c</PathWithFileName>
-      <FilenameWithoutPath>app_suotar.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>136</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar_task.c</PathWithFileName>
-      <FilenameWithoutPath>app_suotar_task.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>137</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_entry\app_entry_point.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_entry\app_entry_point.c</PathWithFileName>
       <FilenameWithoutPath>app_entry_point.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>57</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_msg_utils.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_msg_utils.c</PathWithFileName>
       <FilenameWithoutPath>app_msg_utils.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>58</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</PathWithFileName>
       <FilenameWithoutPath>app_easy_msg_utils.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>59</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_security.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_security.c</PathWithFileName>
       <FilenameWithoutPath>app_easy_security.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>60</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_timer.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_timer.c</PathWithFileName>
       <FilenameWithoutPath>app_easy_timer.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>61</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs.c</PathWithFileName>
       <FilenameWithoutPath>app_customs.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>62</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_task.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs_task.c</PathWithFileName>
       <FilenameWithoutPath>app_customs_task.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>63</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_common.c</PathWithFileName>
-      <FilenameWithoutPath>app_customs_common.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>6</GroupNumber>
-      <FileNumber>145</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\app_modules\src\app_bond_db\app_bond_db.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_bond_db\app_bond_db.c</PathWithFileName>
       <FilenameWithoutPath>app_bond_db.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>64</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\sdk\app_modules\src\app_common\app_utils.c</PathWithFileName>
+      <PathWithFileName>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_utils.c</PathWithFileName>
       <FilenameWithoutPath>app_utils.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
@@ -2847,13 +1735,13 @@
 
   <Group>
     <GroupName>user_config</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>65</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2865,7 +1753,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>66</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2877,7 +1765,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>67</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2889,7 +1777,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>68</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2901,7 +1789,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <FileNumber>69</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2913,7 +1801,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <FileNumber>70</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2925,7 +1813,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <FileNumber>71</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2945,7 +1833,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <FileNumber>72</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2957,7 +1845,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <FileNumber>73</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2977,7 +1865,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <FileNumber>74</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2997,7 +1885,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <FileNumber>75</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/connectivity/simple_beacon/project_environment/simple_beacon.uvprojx
+++ b/connectivity/simple_beacon/project_environment/simple_beacon.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>DA14585</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060750::V5.06 update 6 (build 750)::ARMCC</pCCUsed>
+      <pCCUsed>5060960::V5.06 update 7 (build 960)::.\ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -339,7 +339,7 @@
               <MiscControls>--thumb -c --preinclude da1458x_config_basic.h --preinclude da1458x_config_advanced.h --preinclude user_config.h --bss_threshold=0 --feedback=".\unused_585.txt"</MiscControls>
               <Define></Define>
               <Undefine></Undefine>
-              <IncludePath>.\..\..\..\..\..\sdk\app_modules\api;.\..\..\..\..\..\sdk\ble_stack\controller\em;.\..\..\..\..\..\sdk\ble_stack\controller\llc;.\..\..\..\..\..\sdk\ble_stack\controller\lld;.\..\..\..\..\..\sdk\ble_stack\controller\llm;.\..\..\..\..\..\sdk\ble_stack\ea\api;.\..\..\..\..\..\sdk\ble_stack\em\api;.\..\..\..\..\..\sdk\ble_stack\hci\api;.\..\..\..\..\..\sdk\ble_stack\hci\src;.\..\..\..\..\..\sdk\ble_stack\host\att;.\..\..\..\..\..\sdk\ble_stack\host\att\attc;.\..\..\..\..\..\sdk\ble_stack\host\att\attm;.\..\..\..\..\..\sdk\ble_stack\host\att\atts;.\..\..\..\..\..\sdk\ble_stack\host\gap;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapc;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapm;.\..\..\..\..\..\sdk\ble_stack\host\gatt;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattc;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattm;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cc;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cm;.\..\..\..\..\..\sdk\ble_stack\host\smp;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpc;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpm;.\..\..\..\..\..\sdk\ble_stack\profiles;.\..\..\..\..\..\sdk\ble_stack\profiles\anc;.\..\..\..\..\..\sdk\ble_stack\profiles\anc\ancc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\custom;.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\gatt\gatt_client\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wssc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wsss\api;.\..\..\..\..\..\sdk\ble_stack\rwble;.\..\..\..\..\..\sdk\ble_stack\rwble_hl;.\..\..\..\..\..\sdk\common_project_files;.\..\..\..\..\..\sdk\platform\arch;.\..\..\..\..\..\sdk\platform\arch\boot;.\..\..\..\..\..\sdk\platform\arch\boot\ARM;.\..\..\..\..\..\sdk\platform\arch\boot\GCC;.\..\..\..\..\..\sdk\platform\arch\compiler;.\..\..\..\..\..\sdk\platform\arch\compiler\ARM;.\..\..\..\..\..\sdk\platform\arch\compiler\GCC;.\..\..\..\..\..\sdk\platform\arch\ll;.\..\..\..\..\..\sdk\platform\arch\main;.\..\..\..\..\..\sdk\platform\core_modules\arch_console;.\..\..\..\..\..\sdk\platform\core_modules\common\api;.\..\..\..\..\..\sdk\platform\core_modules\crypto;.\..\..\..\..\..\sdk\platform\core_modules\dbg\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\src;.\..\..\..\..\..\sdk\platform\core_modules\h4tl\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\src;.\..\..\..\..\..\sdk\platform\core_modules\nvds\api;.\..\..\..\..\..\sdk\platform\core_modules\rf\api;.\..\..\..\..\..\sdk\platform\core_modules\rwip\api;.\..\..\..\..\..\sdk\platform\driver\adc;.\..\..\..\..\..\sdk\platform\driver\battery;.\..\..\..\..\..\sdk\platform\driver\ble;.\..\..\..\..\..\sdk\platform\driver\dma;.\..\..\..\..\..\sdk\platform\driver\gpio;.\..\..\..\..\..\sdk\platform\driver\hw_otpc;.\..\..\..\..\..\sdk\platform\driver\i2c;.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom;.\..\..\..\..\..\sdk\platform\driver\pdm;.\..\..\..\..\..\sdk\platform\driver\reg;.\..\..\..\..\..\sdk\platform\driver\rtc;.\..\..\..\..\..\sdk\platform\driver\spi;.\..\..\..\..\..\sdk\platform\driver\spi_flash;.\..\..\..\..\..\sdk\platform\driver\spi_hci;.\..\..\..\..\..\sdk\platform\driver\syscntl;.\..\..\..\..\..\sdk\platform\driver\systick;.\..\..\..\..\..\sdk\platform\driver\timer;.\..\..\..\..\..\sdk\platform\driver\trng;.\..\..\..\..\..\sdk\platform\driver\uart;.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec;.\..\..\..\..\..\sdk\platform\include;.\..\..\..\..\..\sdk\platform\system_library\include;.\..\..\..\..\..\third_party\hash;.\..\..\..\..\..\third_party\rand;.\..\src;.\..\src\config;.\..\src\custom_profile;.\..\..\..\..\..\sdk\platform\utilities\otp_hdr</IncludePath>
+              <IncludePath>C:\DLG_SDK_UNLINKED;</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -370,10 +370,10 @@
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x00000000</DataAddressRange>
             <pXoBase></pXoBase>
-            <ScatterFile>.\..\..\..\..\..\sdk\common_project_files\scatterfiles\scatterfile_common.sct</ScatterFile>
+            <ScatterFile>C:\DLG_SDK_UNLINKED\copied_scatter_585_586.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
-            <Misc>--feedback=".\unused_585.txt" .\..\..\..\..\..\sdk\common_project_files\misc\da14585_symbols.txt  --symdefs=empty_peripheral_template_585_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
+            <Misc>--feedback=".\unused_585.txt" C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\da14585_symbols.txt  --symdefs=empty_peripheral_template_585_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
             <LinkerInputFile></LinkerInputFile>
             <DisabledWarnings></DisabledWarnings>
           </LDads>
@@ -386,17 +386,17 @@
             <File>
               <FileName>system_DA14585_586.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
             </File>
             <File>
               <FileName>startup_DA14585_586.s</FileName>
               <FileType>2</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
             </File>
             <File>
               <FileName>system_DA14531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\system_DA14531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -452,7 +452,7 @@
             <File>
               <FileName>startup_DA14531.s</FileName>
               <FileType>2</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -495,12 +495,12 @@
             <File>
               <FileName>hardfault_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\hardfault_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\hardfault_handler.c</FilePath>
             </File>
             <File>
               <FileName>nmi_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\nmi_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\nmi_handler.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -510,57 +510,57 @@
             <File>
               <FileName>arch_console.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
             </File>
             <File>
               <FileName>nvds.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
             </File>
             <File>
               <FileName>arch_main.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_main.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_main.c</FilePath>
             </File>
             <File>
               <FileName>jump_table.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\jump_table.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\jump_table.c</FilePath>
             </File>
             <File>
               <FileName>arch_sleep.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_sleep.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_sleep.c</FilePath>
             </File>
             <File>
               <FileName>arch_system.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_system.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_system.c</FilePath>
             </File>
             <File>
               <FileName>arch_rom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\main\arch_rom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_rom.c</FilePath>
             </File>
             <File>
               <FileName>chacha20.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\rand\chacha20.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\rand\chacha20.c</FilePath>
             </File>
             <File>
               <FileName>hash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\hash\hash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\hash\hash.c</FilePath>
             </File>
             <File>
               <FileName>da14585_586.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
             </File>
             <File>
               <FileName>da14531.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -584,7 +584,7 @@
             <File>
               <FileName>otp_cs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -640,7 +640,7 @@
             <File>
               <FileName>otp_hdr.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -650,32 +650,32 @@
             <File>
               <FileName>syscntl.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\syscntl\syscntl.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\syscntl\syscntl.c</FilePath>
             </File>
             <File>
               <FileName>gpio.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\gpio\gpio.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\gpio\gpio.c</FilePath>
             </File>
             <File>
               <FileName>wkupct_quadec.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
             </File>
             <File>
               <FileName>battery.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\battery\battery.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\battery\battery.c</FilePath>
             </File>
             <File>
               <FileName>adc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_58x.c</FilePath>
             </File>
             <File>
               <FileName>adc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -731,17 +731,17 @@
             <File>
               <FileName>trng.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\trng\trng.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\trng\trng.c</FilePath>
             </File>
             <File>
               <FileName>spi_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_58x.c</FilePath>
             </File>
             <File>
               <FileName>spi_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -797,32 +797,32 @@
             <File>
               <FileName>spi_flash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
             </File>
             <File>
               <FileName>i2c_eeprom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
             </File>
             <File>
               <FileName>systick.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\systick\systick.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\systick\systick.c</FilePath>
             </File>
             <File>
               <FileName>uart.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\uart\uart.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\uart\uart.c</FilePath>
             </File>
             <File>
               <FileName>hw_otpc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
             </File>
             <File>
               <FileName>hw_otpc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -878,12 +878,12 @@
             <File>
               <FileName>dma.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\dma\dma.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\dma\dma.c</FilePath>
             </File>
             <File>
               <FileName>i2c.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\i2c\i2c.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c\i2c.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -893,27 +893,78 @@
             <File>
               <FileName>rf_585.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
             </File>
             <File>
               <FileName>rwble.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\rwble\rwble.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\rwble\rwble.c</FilePath>
             </File>
             <File>
               <FileName>rwip.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
             </File>
             <File>
               <FileName>ble_arp.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
             </File>
             <File>
               <FileName>rf_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>0</AlwaysBuild>
+                  <GenerateAssemblyFile>0</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>0</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>
@@ -921,404 +972,39 @@
           <GroupName>sdk_profiles</GroupName>
           <Files>
             <File>
-              <FileName>attm_db_128.c</FileName>
+              <FileName>prf.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>custom_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\prf.c</FilePath>
             </File>
             <File>
               <FileName>custs1.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
             </File>
             <File>
               <FileName>custs1_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
             </File>
             <File>
-              <FileName>custs2.c</FileName>
+              <FileName>diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
             </File>
             <File>
-              <FileName>custs2_task.c</FileName>
+              <FileName>diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
             </File>
             <File>
-              <FileName>prf.c</FileName>
+              <FileName>attm_db_128.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\ble_stack\profiles\prf.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
             </File>
             <File>
-              <FileName>prf_utils.c</FileName>
+              <FileName>custom_common.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prf_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1328,127 +1014,82 @@
             <File>
               <FileName>app_default_handlers.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
             </File>
             <File>
               <FileName>app.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app.c</FilePath>
             </File>
             <File>
               <FileName>app_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_task.c</FilePath>
             </File>
             <File>
               <FileName>app_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security.c</FilePath>
             </File>
             <File>
               <FileName>app_security_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
             </File>
             <File>
               <FileName>app_diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
             </File>
             <File>
               <FileName>app_diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
             </File>
             <File>
               <FileName>app_entry_point.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
             </File>
             <File>
               <FileName>app_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_timer.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
             </File>
             <File>
               <FileName>app_customs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
             </File>
             <File>
               <FileName>app_customs_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_customs_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
             </File>
             <File>
               <FileName>app_bond_db.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
             </File>
             <File>
               <FileName>app_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_common\app_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_utils.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1533,7 +1174,7 @@
       <TargetName>DA14586</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060750::V5.06 update 6 (build 750)::ARMCC</pCCUsed>
+      <pCCUsed>5060960::V5.06 update 7 (build 960)::.\ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -1862,7 +1503,7 @@
               <MiscControls>--thumb -c --preinclude da1458x_config_basic.h --preinclude da1458x_config_advanced.h --preinclude user_config.h --bss_threshold=0 --feedback=".\unused_586.txt"</MiscControls>
               <Define>__DA14586__</Define>
               <Undefine></Undefine>
-              <IncludePath>.\..\..\..\..\..\sdk\app_modules\api;.\..\..\..\..\..\sdk\ble_stack\controller\em;.\..\..\..\..\..\sdk\ble_stack\controller\llc;.\..\..\..\..\..\sdk\ble_stack\controller\lld;.\..\..\..\..\..\sdk\ble_stack\controller\llm;.\..\..\..\..\..\sdk\ble_stack\ea\api;.\..\..\..\..\..\sdk\ble_stack\em\api;.\..\..\..\..\..\sdk\ble_stack\hci\api;.\..\..\..\..\..\sdk\ble_stack\hci\src;.\..\..\..\..\..\sdk\ble_stack\host\att;.\..\..\..\..\..\sdk\ble_stack\host\att\attc;.\..\..\..\..\..\sdk\ble_stack\host\att\attm;.\..\..\..\..\..\sdk\ble_stack\host\att\atts;.\..\..\..\..\..\sdk\ble_stack\host\gap;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapc;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapm;.\..\..\..\..\..\sdk\ble_stack\host\gatt;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattc;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattm;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cc;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cm;.\..\..\..\..\..\sdk\ble_stack\host\smp;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpc;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpm;.\..\..\..\..\..\sdk\ble_stack\profiles;.\..\..\..\..\..\sdk\ble_stack\profiles\anc;.\..\..\..\..\..\sdk\ble_stack\profiles\anc\ancc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\custom;.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\gatt\gatt_client\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wssc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wsss\api;.\..\..\..\..\..\sdk\ble_stack\rwble;.\..\..\..\..\..\sdk\ble_stack\rwble_hl;.\..\..\..\..\..\sdk\common_project_files;.\..\..\..\..\..\sdk\platform\arch;.\..\..\..\..\..\sdk\platform\arch\boot;.\..\..\..\..\..\sdk\platform\arch\boot\ARM;.\..\..\..\..\..\sdk\platform\arch\boot\GCC;.\..\..\..\..\..\sdk\platform\arch\compiler;.\..\..\..\..\..\sdk\platform\arch\compiler\ARM;.\..\..\..\..\..\sdk\platform\arch\compiler\GCC;.\..\..\..\..\..\sdk\platform\arch\ll;.\..\..\..\..\..\sdk\platform\arch\main;.\..\..\..\..\..\sdk\platform\core_modules\arch_console;.\..\..\..\..\..\sdk\platform\core_modules\common\api;.\..\..\..\..\..\sdk\platform\core_modules\crypto;.\..\..\..\..\..\sdk\platform\core_modules\dbg\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\src;.\..\..\..\..\..\sdk\platform\core_modules\h4tl\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\src;.\..\..\..\..\..\sdk\platform\core_modules\nvds\api;.\..\..\..\..\..\sdk\platform\core_modules\rf\api;.\..\..\..\..\..\sdk\platform\core_modules\rwip\api;.\..\..\..\..\..\sdk\platform\driver\adc;.\..\..\..\..\..\sdk\platform\driver\battery;.\..\..\..\..\..\sdk\platform\driver\ble;.\..\..\..\..\..\sdk\platform\driver\dma;.\..\..\..\..\..\sdk\platform\driver\gpio;.\..\..\..\..\..\sdk\platform\driver\hw_otpc;.\..\..\..\..\..\sdk\platform\driver\i2c;.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom;.\..\..\..\..\..\sdk\platform\driver\pdm;.\..\..\..\..\..\sdk\platform\driver\reg;.\..\..\..\..\..\sdk\platform\driver\rtc;.\..\..\..\..\..\sdk\platform\driver\spi;.\..\..\..\..\..\sdk\platform\driver\spi_flash;.\..\..\..\..\..\sdk\platform\driver\spi_hci;.\..\..\..\..\..\sdk\platform\driver\syscntl;.\..\..\..\..\..\sdk\platform\driver\systick;.\..\..\..\..\..\sdk\platform\driver\timer;.\..\..\..\..\..\sdk\platform\driver\trng;.\..\..\..\..\..\sdk\platform\driver\uart;.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec;.\..\..\..\..\..\sdk\platform\include;.\..\..\..\..\..\sdk\platform\system_library\include;.\..\..\..\..\..\third_party\hash;.\..\..\..\..\..\third_party\rand;.\..\src;.\..\src\config;.\..\src\custom_profile;.\..\..\..\..\..\sdk\platform\utilities\otp_hdr</IncludePath>
+              <IncludePath>C:\DLG_SDK_UNLINKED;</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -1893,10 +1534,10 @@
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x00000000</DataAddressRange>
             <pXoBase></pXoBase>
-            <ScatterFile>.\..\..\..\..\..\sdk\common_project_files\scatterfiles\scatterfile_common.sct</ScatterFile>
+            <ScatterFile>C:\DLG_SDK_UNLINKED\copied_scatter_585_586.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
-            <Misc>--feedback=".\unused_586.txt" .\..\..\..\..\..\sdk\common_project_files\misc\da14585_symbols.txt  --symdefs=empty_peripheral_template_586_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
+            <Misc>--feedback=".\unused_586.txt" C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\da14585_symbols.txt  --symdefs=empty_peripheral_template_586_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
             <LinkerInputFile></LinkerInputFile>
             <DisabledWarnings></DisabledWarnings>
           </LDads>
@@ -1909,17 +1550,17 @@
             <File>
               <FileName>system_DA14585_586.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
             </File>
             <File>
               <FileName>startup_DA14585_586.s</FileName>
               <FileType>2</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
             </File>
             <File>
               <FileName>system_DA14531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\system_DA14531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -1975,7 +1616,7 @@
             <File>
               <FileName>startup_DA14531.s</FileName>
               <FileType>2</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2018,12 +1659,12 @@
             <File>
               <FileName>hardfault_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\hardfault_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\hardfault_handler.c</FilePath>
             </File>
             <File>
               <FileName>nmi_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\nmi_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\nmi_handler.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2033,57 +1674,57 @@
             <File>
               <FileName>arch_console.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
             </File>
             <File>
               <FileName>nvds.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
             </File>
             <File>
               <FileName>arch_main.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_main.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_main.c</FilePath>
             </File>
             <File>
               <FileName>jump_table.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\jump_table.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\jump_table.c</FilePath>
             </File>
             <File>
               <FileName>arch_sleep.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_sleep.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_sleep.c</FilePath>
             </File>
             <File>
               <FileName>arch_system.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_system.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_system.c</FilePath>
             </File>
             <File>
               <FileName>arch_rom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\main\arch_rom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_rom.c</FilePath>
             </File>
             <File>
               <FileName>chacha20.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\rand\chacha20.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\rand\chacha20.c</FilePath>
             </File>
             <File>
               <FileName>hash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\hash\hash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\hash\hash.c</FilePath>
             </File>
             <File>
               <FileName>da14585_586.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
             </File>
             <File>
               <FileName>da14531.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2107,7 +1748,7 @@
             <File>
               <FileName>otp_cs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2163,7 +1804,7 @@
             <File>
               <FileName>otp_hdr.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2173,32 +1814,32 @@
             <File>
               <FileName>syscntl.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\syscntl\syscntl.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\syscntl\syscntl.c</FilePath>
             </File>
             <File>
               <FileName>gpio.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\gpio\gpio.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\gpio\gpio.c</FilePath>
             </File>
             <File>
               <FileName>wkupct_quadec.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
             </File>
             <File>
               <FileName>battery.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\battery\battery.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\battery\battery.c</FilePath>
             </File>
             <File>
               <FileName>adc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_58x.c</FilePath>
             </File>
             <File>
               <FileName>adc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2254,17 +1895,17 @@
             <File>
               <FileName>trng.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\trng\trng.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\trng\trng.c</FilePath>
             </File>
             <File>
               <FileName>spi_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_58x.c</FilePath>
             </File>
             <File>
               <FileName>spi_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2320,32 +1961,32 @@
             <File>
               <FileName>spi_flash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
             </File>
             <File>
               <FileName>i2c_eeprom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
             </File>
             <File>
               <FileName>systick.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\systick\systick.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\systick\systick.c</FilePath>
             </File>
             <File>
               <FileName>uart.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\uart\uart.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\uart\uart.c</FilePath>
             </File>
             <File>
               <FileName>hw_otpc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
             </File>
             <File>
               <FileName>hw_otpc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -2401,12 +2042,12 @@
             <File>
               <FileName>dma.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\dma\dma.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\dma\dma.c</FilePath>
             </File>
             <File>
               <FileName>i2c.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\i2c\i2c.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c\i2c.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2416,27 +2057,78 @@
             <File>
               <FileName>rf_585.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
             </File>
             <File>
               <FileName>rwble.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\rwble\rwble.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\rwble\rwble.c</FilePath>
             </File>
             <File>
               <FileName>rwip.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
             </File>
             <File>
               <FileName>ble_arp.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
             </File>
             <File>
               <FileName>rf_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>0</AlwaysBuild>
+                  <GenerateAssemblyFile>0</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>0</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>
@@ -2444,404 +2136,39 @@
           <GroupName>sdk_profiles</GroupName>
           <Files>
             <File>
-              <FileName>attm_db_128.c</FileName>
+              <FileName>prf.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>custom_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\prf.c</FilePath>
             </File>
             <File>
               <FileName>custs1.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
             </File>
             <File>
               <FileName>custs1_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
             </File>
             <File>
-              <FileName>custs2.c</FileName>
+              <FileName>diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
             </File>
             <File>
-              <FileName>custs2_task.c</FileName>
+              <FileName>diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
             </File>
             <File>
-              <FileName>prf.c</FileName>
+              <FileName>attm_db_128.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\ble_stack\profiles\prf.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
             </File>
             <File>
-              <FileName>prf_utils.c</FileName>
+              <FileName>custom_common.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prf_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2851,127 +2178,82 @@
             <File>
               <FileName>app_default_handlers.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
             </File>
             <File>
               <FileName>app.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app.c</FilePath>
             </File>
             <File>
               <FileName>app_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_task.c</FilePath>
             </File>
             <File>
               <FileName>app_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security.c</FilePath>
             </File>
             <File>
               <FileName>app_security_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
             </File>
             <File>
               <FileName>app_diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
             </File>
             <File>
               <FileName>app_diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
             </File>
             <File>
               <FileName>app_entry_point.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
             </File>
             <File>
               <FileName>app_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_timer.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
             </File>
             <File>
               <FileName>app_customs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
             </File>
             <File>
               <FileName>app_customs_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_customs_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
             </File>
             <File>
               <FileName>app_bond_db.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
             </File>
             <File>
               <FileName>app_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_common\app_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_utils.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3056,7 +2338,7 @@
       <TargetName>DA14531</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060750::V5.06 update 6 (build 750)::ARMCC</pCCUsed>
+      <pCCUsed>5060960::V5.06 update 7 (build 960)::.\ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -3385,7 +2667,7 @@
               <MiscControls>--thumb -c --preinclude da1458x_config_basic.h --preinclude da1458x_config_advanced.h --preinclude user_config.h --bss_threshold=0 --feedback=".\unused_531.txt"</MiscControls>
               <Define>__DA14531__</Define>
               <Undefine></Undefine>
-              <IncludePath>.\..\..\..\..\..\sdk\app_modules\api;.\..\..\..\..\..\sdk\ble_stack\controller\em;.\..\..\..\..\..\sdk\ble_stack\controller\llc;.\..\..\..\..\..\sdk\ble_stack\controller\lld;.\..\..\..\..\..\sdk\ble_stack\controller\llm;.\..\..\..\..\..\sdk\ble_stack\ea\api;.\..\..\..\..\..\sdk\ble_stack\em\api;.\..\..\..\..\..\sdk\ble_stack\hci\api;.\..\..\..\..\..\sdk\ble_stack\hci\src;.\..\..\..\..\..\sdk\ble_stack\host\att;.\..\..\..\..\..\sdk\ble_stack\host\att\attc;.\..\..\..\..\..\sdk\ble_stack\host\att\attm;.\..\..\..\..\..\sdk\ble_stack\host\att\atts;.\..\..\..\..\..\sdk\ble_stack\host\gap;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapc;.\..\..\..\..\..\sdk\ble_stack\host\gap\gapm;.\..\..\..\..\..\sdk\ble_stack\host\gatt;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattc;.\..\..\..\..\..\sdk\ble_stack\host\gatt\gattm;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cc;.\..\..\..\..\..\sdk\ble_stack\host\l2c\l2cm;.\..\..\..\..\..\sdk\ble_stack\host\smp;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpc;.\..\..\..\..\..\sdk\ble_stack\host\smp\smpm;.\..\..\..\..\..\sdk\ble_stack\profiles;.\..\..\..\..\..\sdk\ble_stack\profiles\anc;.\..\..\..\..\..\sdk\ble_stack\profiles\anc\ancc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bcs\bcss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\bms\bmss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\cts\ctss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\custom;.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\api;.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\gatt\gatt_client\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\api;.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\api;.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udsc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\uds\udss\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wssc\api;.\..\..\..\..\..\sdk\ble_stack\profiles\wss\wsss\api;.\..\..\..\..\..\sdk\ble_stack\rwble;.\..\..\..\..\..\sdk\ble_stack\rwble_hl;.\..\..\..\..\..\sdk\common_project_files;.\..\..\..\..\..\sdk\platform\arch;.\..\..\..\..\..\sdk\platform\arch\boot;.\..\..\..\..\..\sdk\platform\arch\boot\ARM;.\..\..\..\..\..\sdk\platform\arch\boot\GCC;.\..\..\..\..\..\sdk\platform\arch\compiler;.\..\..\..\..\..\sdk\platform\arch\compiler\ARM;.\..\..\..\..\..\sdk\platform\arch\compiler\GCC;.\..\..\..\..\..\sdk\platform\arch\ll;.\..\..\..\..\..\sdk\platform\arch\main;.\..\..\..\..\..\sdk\platform\core_modules\arch_console;.\..\..\..\..\..\sdk\platform\core_modules\common\api;.\..\..\..\..\..\sdk\platform\core_modules\crypto;.\..\..\..\..\..\sdk\platform\core_modules\dbg\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\api;.\..\..\..\..\..\sdk\platform\core_modules\gtl\src;.\..\..\..\..\..\sdk\platform\core_modules\h4tl\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\api;.\..\..\..\..\..\sdk\platform\core_modules\ke\src;.\..\..\..\..\..\sdk\platform\core_modules\nvds\api;.\..\..\..\..\..\sdk\platform\core_modules\rf\api;.\..\..\..\..\..\sdk\platform\core_modules\rwip\api;.\..\..\..\..\..\sdk\platform\driver\adc;.\..\..\..\..\..\sdk\platform\driver\battery;.\..\..\..\..\..\sdk\platform\driver\ble;.\..\..\..\..\..\sdk\platform\driver\dma;.\..\..\..\..\..\sdk\platform\driver\gpio;.\..\..\..\..\..\sdk\platform\driver\hw_otpc;.\..\..\..\..\..\sdk\platform\driver\i2c;.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom;.\..\..\..\..\..\sdk\platform\driver\pdm;.\..\..\..\..\..\sdk\platform\driver\reg;.\..\..\..\..\..\sdk\platform\driver\rtc;.\..\..\..\..\..\sdk\platform\driver\spi;.\..\..\..\..\..\sdk\platform\driver\spi_flash;.\..\..\..\..\..\sdk\platform\driver\spi_hci;.\..\..\..\..\..\sdk\platform\driver\syscntl;.\..\..\..\..\..\sdk\platform\driver\systick;.\..\..\..\..\..\sdk\platform\driver\timer;.\..\..\..\..\..\sdk\platform\driver\trng;.\..\..\..\..\..\sdk\platform\driver\uart;.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec;.\..\..\..\..\..\sdk\platform\include;.\..\..\..\..\..\sdk\platform\system_library\include;.\..\..\..\..\..\third_party\hash;.\..\..\..\..\..\third_party\irng;.\..\..\..\..\..\third_party\rand;.\..\src;.\..\src\config;.\..\src\custom_profile;.\..\..\..\..\..\sdk\platform\utilities\otp_cs;.\..\..\..\..\..\sdk\platform\utilities\otp_hdr</IncludePath>
+              <IncludePath>C:\DLG_SDK_UNLINKED</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -3416,10 +2698,10 @@
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x00000000</DataAddressRange>
             <pXoBase></pXoBase>
-            <ScatterFile>..\..\..\..\..\sdk\common_project_files\scatterfiles\DA14531.sct</ScatterFile>
+            <ScatterFile>C:\DLG_SDK_UNLINKED\copied_scatter_531.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
-            <Misc>--feedback=".\unused_531.txt" .\..\..\..\..\..\sdk\common_project_files\misc\da14531_symbols.txt --symdefs=empty_peripheral_template_531_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
+            <Misc>--feedback=".\unused_531.txt" C:\DLG_SDK_UNLINKED\sdk\common_project_files\misc\da14531_symbols.txt --symdefs=empty_peripheral_template_531_symdef.txt --any_placement=best_fit --datacompressor off</Misc>
             <LinkerInputFile></LinkerInputFile>
             <DisabledWarnings></DisabledWarnings>
           </LDads>
@@ -3432,7 +2714,7 @@
             <File>
               <FileName>system_DA14585_586.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14585_586.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3488,7 +2770,7 @@
             <File>
               <FileName>startup_DA14585_586.s</FileName>
               <FileType>2</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14585_586.s</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3531,22 +2813,22 @@
             <File>
               <FileName>system_DA14531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\system_DA14531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\system_DA14531.c</FilePath>
             </File>
             <File>
               <FileName>startup_DA14531.s</FileName>
               <FileType>2</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\boot\ARM\startup_DA14531.s</FilePath>
             </File>
             <File>
               <FileName>hardfault_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\hardfault_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\hardfault_handler.c</FilePath>
             </File>
             <File>
               <FileName>nmi_handler.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\nmi_handler.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\nmi_handler.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3556,52 +2838,52 @@
             <File>
               <FileName>arch_console.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\arch_console\arch_console.c</FilePath>
             </File>
             <File>
               <FileName>nvds.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\nvds\src\nvds.c</FilePath>
             </File>
             <File>
               <FileName>arch_main.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_main.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_main.c</FilePath>
             </File>
             <File>
               <FileName>jump_table.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\jump_table.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\jump_table.c</FilePath>
             </File>
             <File>
               <FileName>arch_sleep.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_sleep.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_sleep.c</FilePath>
             </File>
             <File>
               <FileName>arch_system.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\arch\main\arch_system.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_system.c</FilePath>
             </File>
             <File>
               <FileName>arch_rom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\arch\main\arch_rom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\arch\main\arch_rom.c</FilePath>
             </File>
             <File>
               <FileName>chacha20.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\rand\chacha20.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\rand\chacha20.c</FilePath>
             </File>
             <File>
               <FileName>hash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\third_party\hash\hash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\third_party\hash\hash.c</FilePath>
             </File>
             <File>
               <FileName>da14585_586.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14585_586.lib</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3625,17 +2907,17 @@
             <File>
               <FileName>da14531.lib</FileName>
               <FileType>4</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\system_library\output\Keil_5\da14531.lib</FilePath>
             </File>
             <File>
               <FileName>otp_cs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_cs\otp_cs.c</FilePath>
             </File>
             <File>
               <FileName>otp_hdr.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\utilities\otp_hdr\otp_hdr.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3645,27 +2927,27 @@
             <File>
               <FileName>syscntl.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\syscntl\syscntl.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\syscntl\syscntl.c</FilePath>
             </File>
             <File>
               <FileName>gpio.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\gpio\gpio.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\gpio\gpio.c</FilePath>
             </File>
             <File>
               <FileName>wkupct_quadec.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\wkupct_quadec\wkupct_quadec.c</FilePath>
             </File>
             <File>
               <FileName>battery.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\battery\battery.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\battery\battery.c</FilePath>
             </File>
             <File>
               <FileName>adc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_58x.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3721,17 +3003,17 @@
             <File>
               <FileName>adc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\adc\adc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\adc\adc_531.c</FilePath>
             </File>
             <File>
               <FileName>trng.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\trng\trng.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\trng\trng.c</FilePath>
             </File>
             <File>
               <FileName>spi_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_58x.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3787,32 +3069,32 @@
             <File>
               <FileName>spi_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\spi\spi_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi\spi_531.c</FilePath>
             </File>
             <File>
               <FileName>spi_flash.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\spi_flash\spi_flash.c</FilePath>
             </File>
             <File>
               <FileName>i2c_eeprom.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c_eeprom\i2c_eeprom.c</FilePath>
             </File>
             <File>
               <FileName>systick.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\systick\systick.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\systick\systick.c</FilePath>
             </File>
             <File>
               <FileName>uart.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\driver\uart\uart.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\uart\uart.c</FilePath>
             </File>
             <File>
               <FileName>hw_otpc_58x.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_58x.c</FilePath>
               <FileOption>
                 <CommonProperty>
                   <UseCPPCompiler>2</UseCPPCompiler>
@@ -3868,17 +3150,17 @@
             <File>
               <FileName>hw_otpc_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\hw_otpc\hw_otpc_531.c</FilePath>
             </File>
             <File>
               <FileName>dma.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\dma\dma.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\dma\dma.c</FilePath>
             </File>
             <File>
               <FileName>i2c.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\driver\i2c\i2c.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\driver\i2c\i2c.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3888,27 +3170,78 @@
             <File>
               <FileName>rf_585.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_585.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>0</AlwaysBuild>
+                  <GenerateAssemblyFile>0</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>0</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>rwble.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\rwble\rwble.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\rwble\rwble.c</FilePath>
             </File>
             <File>
               <FileName>rwip.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rwip\src\rwip.c</FilePath>
             </File>
             <File>
               <FileName>ble_arp.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\ble_arp.c</FilePath>
             </File>
             <File>
               <FileName>rf_531.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\platform\core_modules\rf\src\rf_531.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3916,404 +3249,39 @@
           <GroupName>sdk_profiles</GroupName>
           <Files>
             <File>
-              <FileName>attm_db_128.c</FileName>
+              <FileName>prf.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc.c</FilePath>
-            </File>
-            <File>
-              <FileName>basc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\basc\src\basc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\bas\bass\src\bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>blpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blpc\src\blpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps.c</FilePath>
-            </File>
-            <File>
-              <FileName>blps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\blp\blps\src\blps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc.c</FilePath>
-            </File>
-            <File>
-              <FileName>disc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\disc\src\disc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
-            </File>
-            <File>
-              <FileName>diss_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt.c</FilePath>
-            </File>
-            <File>
-              <FileName>findt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findt\src\findt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpbh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpbh\src\hogpbh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogpd_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogpd\src\hogpd_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh.c</FilePath>
-            </File>
-            <File>
-              <FileName>hogprh_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hogp\hogprh\src\hogprh_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrpc\src\hrpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps.c</FilePath>
-            </File>
-            <File>
-              <FileName>hrps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\hrp\hrps\src\hrps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpc\src\htpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt.c</FilePath>
-            </File>
-            <File>
-              <FileName>htpt_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\htp\htpt\src\htpt_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxm_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxm\src\proxm_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prox\proxr\src\proxr_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>scppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scppc\src\scppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>scpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\scpp\scpps\src\scpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>anpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anpc\src\anpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps.c</FilePath>
-            </File>
-            <File>
-              <FileName>anps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\anp\anps\src\anps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscpc\src\cscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cscp\cscps\src\cscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>glpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glpc\src\glpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps.c</FilePath>
-            </File>
-            <File>
-              <FileName>glps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\glp\glps\src\glps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc.c</FilePath>
-            </File>
-            <File>
-              <FileName>paspc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\paspc\src\paspc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps.c</FilePath>
-            </File>
-            <File>
-              <FileName>pasps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\pasp\pasps\src\pasps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscpc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscpc\src\rscpc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps.c</FilePath>
-            </File>
-            <File>
-              <FileName>rscps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\rscp\rscps\src\rscps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc.c</FilePath>
-            </File>
-            <File>
-              <FileName>tipc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tipc\src\tipc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips.c</FilePath>
-            </File>
-            <File>
-              <FileName>tips_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\tip\tips\src\tips_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl.c</FilePath>
-            </File>
-            <File>
-              <FileName>findl_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\find\findl\src\findl_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc.c</FilePath>
-            </File>
-            <File>
-              <FileName>cppc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cppc\src\cppc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps.c</FilePath>
-            </File>
-            <File>
-              <FileName>cpps_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\cpp\cpps\src\cpps_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc.c</FilePath>
-            </File>
-            <File>
-              <FileName>lanc_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lanc\src\lanc_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans.c</FilePath>
-            </File>
-            <File>
-              <FileName>lans_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\lan\lans\src\lans_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\suota\suotar\src\suotar_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>custom_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\prf.c</FilePath>
             </File>
             <File>
               <FileName>custs1.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1.c</FilePath>
             </File>
             <File>
               <FileName>custs1_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custs\src\custs1_task.c</FilePath>
             </File>
             <File>
-              <FileName>custs2.c</FileName>
+              <FileName>diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss.c</FilePath>
             </File>
             <File>
-              <FileName>custs2_task.c</FileName>
+              <FileName>diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\custom\custs\src\custs2_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\dis\diss\src\diss_task.c</FilePath>
             </File>
             <File>
-              <FileName>prf.c</FileName>
+              <FileName>attm_db_128.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\ble_stack\profiles\prf.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\host\att\attm\attm_db_128.c</FilePath>
             </File>
             <File>
-              <FileName>prf_utils.c</FileName>
+              <FileName>custom_common.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\ble_stack\profiles\prf_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\ble_stack\profiles\custom\custom_common.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -4323,127 +3291,82 @@
             <File>
               <FileName>app_default_handlers.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_default_hnd\app_default_handlers.c</FilePath>
             </File>
             <File>
               <FileName>app.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app.c</FilePath>
             </File>
             <File>
               <FileName>app_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_task.c</FilePath>
             </File>
             <File>
               <FileName>app_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security.c</FilePath>
             </File>
             <File>
               <FileName>app_security_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_bass_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_bass\app_bass_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_findme_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_findme\app_findme_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_proxr_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_proxr\app_proxr_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_sec\app_security_task.c</FilePath>
             </File>
             <File>
               <FileName>app_diss.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss.c</FilePath>
             </File>
             <File>
               <FileName>app_diss_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_suotar_task.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_suotar\app_suotar_task.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_diss\app_diss_task.c</FilePath>
             </File>
             <File>
               <FileName>app_entry_point.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_entry\app_entry_point.c</FilePath>
             </File>
             <File>
               <FileName>app_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_msg_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_msg_utils.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_security.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_security.c</FilePath>
             </File>
             <File>
               <FileName>app_easy_timer.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_easy\app_easy_timer.c</FilePath>
             </File>
             <File>
               <FileName>app_customs.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs.c</FilePath>
             </File>
             <File>
               <FileName>app_customs_task.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
-            </File>
-            <File>
-              <FileName>app_customs_common.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>.\..\..\..\..\..\sdk\app_modules\src\app_custs\app_customs_common.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_custs\app_customs_task.c</FilePath>
             </File>
             <File>
               <FileName>app_bond_db.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_bond_db\app_bond_db.c</FilePath>
             </File>
             <File>
               <FileName>app_utils.c</FileName>
               <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\sdk\app_modules\src\app_common\app_utils.c</FilePath>
+              <FilePath>C:\DLG_SDK_UNLINKED\sdk\app_modules\src\app_common\app_utils.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -4535,12 +3458,7 @@
   <LayerInfo>
     <Layers>
       <Layer>
-        <LayName>&lt;Project Info&gt;</LayName>
-        <LayDesc></LayDesc>
-        <LayUrl></LayUrl>
-        <LayKeys></LayKeys>
-        <LayCat></LayCat>
-        <LayLic></LayLic>
+        <LayName>simple_beacon</LayName>
         <LayTarg>0</LayTarg>
         <LayPrjMark>1</LayPrjMark>
       </Layer>


### PR DESCRIPTION
Here are the main update done on the example:

- Update the readme to fix the minor typo about the used SDK, the latest SDK 6.0.14 is supported by the example
- Remove unused files from KEIL projects (SDK profile and SDK app categories) This is to reduce compilation time