### PR TITLE
Disabe CFG_ENABLE_SMP_SECURE Flag --simple_beacon Example

### DIFF
--- a/connectivity/simple_beacon/src/config/da1458x_config_advanced.h
+++ b/connectivity/simple_beacon/src/config/da1458x_config_advanced.h
@@ -94,7 +94,7 @@
 /*              support secure connections, it is recommended to undefine CFG_ENABLE_SMP_SECURE in order to     */
 /*              enable faster start-up time and reduce code size.                                               */
 /****************************************************************************************************************/
-#define CFG_ENABLE_SMP_SECURE
+#undef CFG_ENABLE_SMP_SECURE
 
 /****************************************************************************************************************/
 /* Uses ChaCha20 random number generator instead of the C standard library random number generator.             */


### PR DESCRIPTION
Following issue /28 the secure connection flag is disabled in this example since it is non connectable.