### PR TITLE
correct configuration for the DA14531 for Enabling pads

### DIFF
--- a/interfaces/accel-Sensor/src/platform/user_periph_setup.c
+++ b/interfaces/accel-Sensor/src/platform/user_periph_setup.c
@@ -118,7 +118,7 @@ void periph_init(void)
     i2c_init(&i2c_cfg);
 
     // Enable the pads
-    SetBits16(SYS_CTRL_REG, PAD_LATCH_EN, 1);
+    GPIO_set_pad_latch_en(true);
 		
 	ADXL345_init(); //Initialise the ADXL345
 }


### PR DESCRIPTION
Correct the configuration for Enable the pads for the DA14531. 

