### PR TITLE
Linkscript performance

### DIFF
--- a/dlg_make_keil5_env_v2.000.py
+++ b/dlg_make_keil5_env_v2.000.py
@@ -1010,7 +1010,6 @@ def run_application(sdkpath):
 
 # start application
 if __name__ == "__main__":
-    starttime=time.time()
     # construct the argument parse and parse the arguments
     ap = argparse.ArgumentParser()
     ap.add_argument("-sdkpath", "--sdkpath", required=True,
@@ -1019,7 +1018,4 @@ if __name__ == "__main__":
 
     # print("SDK location {},is the sdk path".format(args["sdkpath"]))
     run_application(args["sdkpath"])
-    endtime=time.time()
-    difftime=endtime-starttime
-    print("script took "+str(difftime)+"s....")
 # run_individual_project_file(dirnames,args["sdkpath"])

--- a/dlg_make_keil5_env_v2.000.py
+++ b/dlg_make_keil5_env_v2.000.py
@@ -72,6 +72,7 @@ import re
 import argparse
 import xml.etree.ElementTree as ET
 from typing import NamedTuple
+import time
 
 '''
 Classes
@@ -840,7 +841,7 @@ def verify_dlg_sdk_proj_env_directory(path):
     else:
         return True
 
-
+L
 def handle_space_in_path(path):
     """
     For every directory in given path with a space in the string, this function will replace the
@@ -1009,6 +1010,7 @@ def run_application(sdkpath):
 
 # start application
 if __name__ == "__main__":
+    starttime=time.time()
     # construct the argument parse and parse the arguments
     ap = argparse.ArgumentParser()
     ap.add_argument("-sdkpath", "--sdkpath", required=True,
@@ -1017,4 +1019,7 @@ if __name__ == "__main__":
 
     # print("SDK location {},is the sdk path".format(args["sdkpath"]))
     run_application(args["sdkpath"])
+    endtime=time.time()
+    difftime=endtime-starttime
+    print("script took "+str(difftime)+"s....")
 # run_individual_project_file(dirnames,args["sdkpath"])

--- a/dlg_make_keil5_env_v2.000.py
+++ b/dlg_make_keil5_env_v2.000.py
@@ -72,7 +72,6 @@ import re
 import argparse
 import xml.etree.ElementTree as ET
 from typing import NamedTuple
-import time
 
 '''
 Classes

--- a/dlg_make_keil5_env_v2.000.py
+++ b/dlg_make_keil5_env_v2.000.py
@@ -379,7 +379,7 @@ def build_uvprojx_element_file(xml_sub_element, xml_tag, working_dir):
                 else:
                     # print("WARNING :: IT IS AN INVALID DIRECTORY PATH, THIS PATH WILL BE AUTOMATICALLY REMOVED...")
                     pass
-                print(single_text)
+                #print(single_text)
     print("")
 
     # my_file = open(DLG_UVPROJX_NAME,"w")
@@ -586,7 +586,7 @@ def build_uvprojx_element_various_controls(xml_sub_element, xml_tag, working_dir
 
     # Print updated_data in a readable format.
     updated_data = updated_data.replace(";", ";\r\n")
-    print("IncludePath ELEMENT TEXT:\r\n" + updated_data + "END OF IncludePath ELEMENT TEXT.\r\n")
+    #print("IncludePath ELEMENT TEXT:\r\n" + updated_data + "END OF IncludePath ELEMENT TEXT.\r\n")
 
     # print(temp_text)
     # print(updated_data[:-1])
@@ -841,7 +841,7 @@ def verify_dlg_sdk_proj_env_directory(path):
     else:
         return True
 
-L
+
 def handle_space_in_path(path):
     """
     For every directory in given path with a space in the string, this function will replace the


### PR DESCRIPTION
The performance of the link script was pretty bad due to a lot of print statements. This PR removes those and the result is:
- cleaning took 107 seconds and now takes 43s
- linking took 49s and now takes 23s
The exact numbers depend on multiple factors such as the system it runs on and the lenght of the paths to print but this is roughly a 50% performance increase.