### PR TITLE
Update CFG_RET_DATA_SIZE for dynamic L2CAP example

### DIFF
--- a/features/dynamic_L2CAP_Packet_size_Optimization/src/config/da1458x_config_advanced.h
+++ b/features/dynamic_L2CAP_Packet_size_Optimization/src/config/da1458x_config_advanced.h
@@ -213,7 +213,7 @@
 /* Maximum retention memory in bytes. The base address of the retention data is calculated from the selected    */
 /* size.                                                                                                        */
 /****************************************************************************************************************/
-#define CFG_RET_DATA_SIZE    (2048)
+#define CFG_RET_DATA_SIZE    (10240 + 2048)
 
 /****************************************************************************************************************/
 /* Maximum uninitialized retained data required by the application.                                             */
@@ -437,7 +437,7 @@
 /* Maximum retention memory in bytes. The base address of the retention data is calculated from the selected    */
 /* size.                                                                                                        */
 /****************************************************************************************************************/
-#define CFG_RET_DATA_SIZE    (2048)
+#define CFG_RET_DATA_SIZE    (10240 + 2048)
 
 /****************************************************************************************************************/
 /* Maximum uninitialized retained data required by the application.                                             */

--- a/features/dynamic_L2CAP_Packet_size_Optimization/src/user_throughput_opt.c
+++ b/features/dynamic_L2CAP_Packet_size_Optimization/src/user_throughput_opt.c
@@ -94,7 +94,7 @@ typedef struct
 }tput_envt_t;
 
 
-tput_envt_t tput_env																		__attribute__((section(".bss.")));
+tput_envt_t tput_env																		__SECTION_ZERO("retention_mem_area0");
 
 
 /**


### PR DESCRIPTION
Increase CFG_RET_DATA_SIZE and move tput_env to retention_mem_area0